### PR TITLE
Fix Bytes per second units

### DIFF
--- a/SpookStation/SpookStationGui/main.py
+++ b/SpookStation/SpookStationGui/main.py
@@ -283,10 +283,20 @@ class SpookStationWidget(BoxLayout):
         deviceManager.bytesSentCallback = self.OnBytesSentChange
 
     def OnBytesReceivedChange(self, bytesReceived, *largs):
-        self.ids.bytesReceivedLabel.text = str(bytesReceived)
+        self.ids.bytesReceivedLabel.text = self.BytesToHumanReadable(bytesReceived)
 
     def OnBytesSentChange(self, bytesSent, *largs):
-        self.ids.bytesSentLabel.text = str(bytesSent)
+        self.ids.bytesSentLabel.text = self.BytesToHumanReadable(bytesSent)
+
+    def BytesToHumanReadable(self, bytes):
+        if bytes < 1024:
+            return str(round(bytes)) + " B/s"
+        elif bytes < 1024**2:
+            return str(round(bytes / 1024, 1)) + " KB/s"
+        elif bytes < 1024**3:
+            return str(round(bytes / 1024**2, 1)) + " MB/s"
+        else:
+            return str(round(bytes / 1024**3, 1)) + " GB/s"
 
     def AddNewDeviceInfoWidget(self, deviceType, deviceName):
         # If no added devices widget is in the list, remove it

--- a/SpookStation/SpookStationGui/spookstation.kv
+++ b/SpookStation/SpookStationGui/spookstation.kv
@@ -564,8 +564,8 @@
 
             GridLayout:
                 id: bytesReceivedGrid
-                cols:3
-                width: '96dp'
+                cols:2
+                width: '130dp'
                 size_hint_x: None
                 Image:
                     id: bytesReceivedImage
@@ -575,20 +575,15 @@
                     color: 'white'
                 Label:
                     id: bytesReceivedLabel
-                    text: '0'
+                    text: '0 B/s'
                     size_hint: (1, 1)
-                    color: 'black'
-                    bold: True
-                Label:
-                    id: bytesReceivedTextLabel
-                    text: 'B/s'
                     color: 'black'
                     bold: True
 
             GridLayout:
                 id: bytesSentGrid
-                cols:3
-                width: '96dp'
+                cols:2
+                width: '130dp'
                 size_hint_x: None
                 Image:
                     id: bytesSentImage
@@ -598,13 +593,8 @@
                     color: 'white'
                 Label:
                     id: bytesSentLabel
-                    text: '0'
+                    text: '0 B/s'
                     size_hint: (1, 1)
-                    color: 'black'
-                    bold: True
-                Label:
-                    id: bytesSentTextLabel
-                    text: 'B/s'
                     color: 'black'
                     bold: True
     


### PR DESCRIPTION
Added units for bytes per second. Example:

![image](https://github.com/DouglasHalse/spook-station/assets/48091729/b61f1b5d-c4bc-4861-89d8-fde377f13879)

![image](https://github.com/DouglasHalse/spook-station/assets/48091729/d5b67248-ec8f-473d-b09d-16b467d1ab8e)

![image](https://github.com/DouglasHalse/spook-station/assets/48091729/58d599d6-7fe2-4d76-9656-ffb5f2de5034)
